### PR TITLE
infra/DA-0000/Fix Container Build

### DIFF
--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -1,10 +1,26 @@
-FROM ubuntu:latest AS base
-RUN apt-get -y update
+FROM debian:buster-slim as base
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get -y install wget pkg-config zip g++ zlib1g-dev unzip python3 git make bash-completion python apt-utils
-RUN apt-get -y install  openjdk-8-jdk-headless
+ENV TZ=America/Los_Angeles
+RUN apt-get -y update
+RUN apt-get -y install \
+	wget pkg-config zip \
+	g++ zlib1g-dev unzip python3 \
+	git make bash-completion \
+	python apt-utils gnupg2 \
+	software-properties-common
+
+# install java for bazel
+RUN mkdir -p /usr/share/man/man1/
+RUN wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | apt-key add -
+RUN add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/
+RUN apt-get -y update
+RUN apt-get -y install adoptopenjdk-8-hotspot
+
+# install python3 distutils for bazel
 RUN apt-get -y install python3-distutils
 RUN apt-get install --fix-broken
+
+# install bazel
 RUN wget https://github.com/bazelbuild/bazel/releases/download/0.29.1/bazel_0.29.1-linux-x86_64.deb
 RUN dpkg -i bazel_0.29.1-linux-x86_64.deb
 


### PR DESCRIPTION
This commit updates the Dockerfile to use the same base image for all
build steps.

We were, for some reason, using different images for building ZetaSQL
and running it. Those images have since diverged enough to cause linked
library issues at runtime.

The python library is unaffected.